### PR TITLE
Update from 3.4.1 to 3.5.2

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  mesters_org: django_dev

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  mesters_org: django_dev

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,7 +38,7 @@ about:
   license_family: BSD
   license_file: LICENSE
   summary: ASGI in-memory channel layer
-  doc_url: https://asgi.readthedocs.io/en/latest/
+  doc_url: https://asgi.readthedocs.io/
   dev_url: https://github.com/django/asgiref
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,15 +13,16 @@ build:
   noarch: python
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps -vv
+  skip: True # [py<36]
 
 requirements:
   host:
-    - python >=3.6
+    - python
     - pip
     - setuptools
     - wheel
   run:
-    - python >=3.6
+    - python
     - typing_extensions
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,6 +39,10 @@ about:
   license_file: LICENSE
   license_url: https://github.com/django/asgiref/blob/main/LICENSE
   summary: ASGI in-memory channel layer
+  description: |
+    ASGI is a standard for Python asynchronous web apps and servers
+    to communicate with each other, and positioned as an asynchronous
+    successor to WSGI.
   doc_url: https://asgi.readthedocs.io/
   dev_url: https://github.com/django/asgiref
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps -vv
-  skip: True # [py<36]
+  skip: True # [py<37]
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,6 @@ source:
   sha256: 4a29362a6acebe09bf1d6640db38c1dc3d9217c68e6f9f6204d72667fc19a424
 
 build:
-  noarch: python
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps -vv
   skip: True # [py<36]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "asgiref" %}
-{% set version = "3.4.1" %}
+{% set version = "3.5.2" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 4ef1ab46b484e3c706329cedeff284a5d40824200638503f5768edb6de7d58e9
+  sha256: 4a29362a6acebe09bf1d6640db38c1dc3d9217c68e6f9f6204d72667fc19a424
 
 build:
   noarch: python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,7 @@ requirements:
     - wheel
   run:
     - python
-    - typing_extensions
+    - typing_extensions #[py<38]
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,6 +37,7 @@ about:
   license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE
+  license_url: https://github.com/django/asgiref/blob/main/LICENSE
   summary: ASGI in-memory channel layer
   doc_url: https://asgi.readthedocs.io/
   dev_url: https://github.com/django/asgiref

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,7 @@ requirements:
     - wheel
   run:
     - python
-    - typing_extensions #[py<38]
+    - typing_extensions # [py<38]
 
 test:
   imports:


### PR DESCRIPTION
Update asgiref from version 3.4.1 to 3.5.2.

This is a dependency for django 4 (ticket [DSNC-4153](https://anaconda.atlassian.net/browse/DSNC-4153)

# Package Info

Home: https://github.com/django/asgiref
Source: https://github.com/django/asgiref/archive/refs/tags/3.5.2.tar.gz
Documentation: https://asgi.readthedocs.io/
Change log: https://github.com/django/asgiref/compare/3.4.1...3.5.2

# Actions
* Update to version 3.5.2.
* Remove `noarch`
* Update documentation link
* Convert python version specification format