### PR TITLE
Update 3.8.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@ requirements:
     - wheel
   run:
     - python
-    - typing_extensions >=4
+    - typing_extensions >=4 # [py<311]
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,8 +10,8 @@ source:
   sha256: c343bd80a0bec947a9860adb4c432ffa7db769836c64238fc34bdc3fec84d590
 build:
   number: 0
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
-  skip: True # [py<37]
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed -vvv
+  skip: True # [py<38]
 
 requirements:
   host:
@@ -36,7 +36,6 @@ about:
   license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE
-  license_url: https://github.com/django/asgiref/blob/main/LICENSE
   summary: ASGI in-memory channel layer
   description: |
     ASGI is a standard for Python asynchronous web apps and servers

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "asgiref" %}
-{% set version = "3.5.2" %}
+{% set version = "3.8.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,8 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 4a29362a6acebe09bf1d6640db38c1dc3d9217c68e6f9f6204d72667fc19a424
-
+  sha256: c343bd80a0bec947a9860adb4c432ffa7db769836c64238fc34bdc3fec84d590
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps -vv
@@ -22,7 +21,7 @@ requirements:
     - wheel
   run:
     - python
-    - typing_extensions # [py<38]
+    - typing_extensions >=4
 
 test:
   imports:


### PR DESCRIPTION
## ☆Asgiref 3.8.1 Update ☆
[Jira Ticket](https://anaconda.atlassian.net/browse/PKG-5525)
[Upstream](https://github.com/django/asgiref)
# Changes
- Updated version number and `sha256`
- Minor dependency update and standardized meta.yaml formatting
